### PR TITLE
[1.19.2] render type datagen and registration

### DIFF
--- a/Common/src/main/java/com/almostreliable/almostlib/AlmostManager.java
+++ b/Common/src/main/java/com/almostreliable/almostlib/AlmostManager.java
@@ -6,10 +6,15 @@ import com.almostreliable.almostlib.registry.*;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Simple manager to hold registrations for a specified namespace.
  */
 public class AlmostManager {
+
+    public static Set<String> REGISTERED_MODS = new HashSet<>();
 
     private final String namespace;
     private final DataGenManager dataGen;
@@ -34,6 +39,7 @@ public class AlmostManager {
      * @return A new AlmostManager.
      */
     public static AlmostManager create(String namespace) {
+        REGISTERED_MODS.add(namespace);
         return new AlmostManager(namespace);
     }
 

--- a/Common/src/main/java/com/almostreliable/almostlib/datagen/template/BlockStateTemplates.java
+++ b/Common/src/main/java/com/almostreliable/almostlib/datagen/template/BlockStateTemplates.java
@@ -1,6 +1,7 @@
 package com.almostreliable.almostlib.datagen.template;
 
 import com.almostreliable.almostlib.datagen.provider.BlockStateProvider;
+import com.almostreliable.almostlib.datagen.template.LayeredModelTemplate.RenderLayer;
 import com.almostreliable.almostlib.registry.BlockEntry;
 import com.almostreliable.almostlib.util.Rotation;
 import net.minecraft.data.models.blockstates.MultiVariantGenerator;
@@ -24,28 +25,38 @@ public class BlockStateTemplates {
     }
 
     public static <T extends Block> void horizontalFacing(BlockEntry<T> entry, BlockStateProvider provider) {
+        horizontalFacing(RenderLayer.SOLID, entry, provider);
+    }
+
+    public static <T extends Block> void horizontalFacing(RenderLayer renderLayer, BlockEntry<T> entry, BlockStateProvider provider) {
         Block block = entry.get();
         var mapping = new TextureMapping()
             .put(TextureSlot.FRONT, TextureMapping.getBlockTexture(block, "_front"))
             .put(TextureSlot.SIDE, TextureMapping.getBlockTexture(block))
             .put(TextureSlot.TOP, TextureMapping.getBlockTexture(block));
-        ResourceLocation modelLocation = ModelTemplates.CUBE_ORIENTABLE.create(block, mapping, provider.getModelConsumer());
+        ResourceLocation modelLocation = LayeredModelTemplate.of(ModelTemplates.CUBE_ORIENTABLE, renderLayer)
+            .create(block, mapping, provider.getModelConsumer());
 
-        provider.createVariantFor(block, (model) -> {
+        provider.createVariantFor(block, model -> {
             model.model(modelLocation)
                 .yRotation(Rotation.ofHorizontalFacing(model.getValue(BlockStateProperties.HORIZONTAL_FACING)));
         }, BlockStateProperties.HORIZONTAL_FACING);
     }
 
     public static <T extends Block> void facing(BlockEntry<T> entry, BlockStateProvider provider) {
+        facing(RenderLayer.SOLID, entry, provider);
+    }
+
+    public static <T extends Block> void facing(RenderLayer renderLayer, BlockEntry<T> entry, BlockStateProvider provider) {
         Block block = entry.get();
         var mapping = new TextureMapping()
             .put(TextureSlot.FRONT, TextureMapping.getBlockTexture(block, "_front"))
             .put(TextureSlot.SIDE, TextureMapping.getBlockTexture(block))
             .put(TextureSlot.TOP, TextureMapping.getBlockTexture(block));
-        ResourceLocation modelLocation = ModelTemplates.CUBE_ORIENTABLE.create(block, mapping, provider.getModelConsumer());
+        ResourceLocation modelLocation = LayeredModelTemplate.of(ModelTemplates.CUBE_ORIENTABLE, renderLayer)
+            .create(block, mapping, provider.getModelConsumer());
 
-        provider.createVariantFor(block, (model) -> {
+        provider.createVariantFor(block, model -> {
             model.model(modelLocation)
                 .yRotation(Rotation.ofHorizontalFacing(model.getValue(BlockStateProperties.FACING)))
                 .xRotation(Rotation.ofVerticalFacing(model.getValue(BlockStateProperties.FACING)));

--- a/Common/src/main/java/com/almostreliable/almostlib/datagen/template/LayeredModelTemplate.java
+++ b/Common/src/main/java/com/almostreliable/almostlib/datagen/template/LayeredModelTemplate.java
@@ -1,0 +1,60 @@
+package com.almostreliable.almostlib.datagen.template;
+
+import com.almostreliable.almostlib.mixin.ModelTemplateAccessor;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.data.models.model.ModelTemplate;
+import net.minecraft.data.models.model.TextureMapping;
+import net.minecraft.data.models.model.TextureSlot;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+public class LayeredModelTemplate extends ModelTemplate {
+
+    private final RenderLayer renderLayer;
+
+    public LayeredModelTemplate(RenderLayer renderLayer, Optional<ResourceLocation> model, Optional<String> suffix, TextureSlot... textureSlots) {
+        super(model, suffix, textureSlots);
+        this.renderLayer = renderLayer;
+    }
+
+    public static LayeredModelTemplate of(ModelTemplate modelTemplate, RenderLayer renderLayer) {
+        ModelTemplateAccessor template = (ModelTemplateAccessor) modelTemplate;
+        return new LayeredModelTemplate(
+            renderLayer, template.getModel(), template.getSuffix(), template.getRequiredSlots().toArray(new TextureSlot[0])
+        );
+    }
+
+    @Override
+    public ResourceLocation create(ResourceLocation resourceLocation, TextureMapping textureMapping, BiConsumer<ResourceLocation, Supplier<JsonElement>> biConsumer) {
+        return super.create(resourceLocation, textureMapping, (rl, supplier) -> injectRenderLayer(rl, supplier, biConsumer));
+    }
+
+    private void injectRenderLayer(ResourceLocation resourceLocation, Supplier<JsonElement> supplier, BiConsumer<ResourceLocation, Supplier<JsonElement>> biConsumer) {
+        var json = supplier.get();
+        if (json instanceof JsonObject jsonObject) {
+            jsonObject.addProperty("render_type", renderLayer.name);
+        }
+        biConsumer.accept(resourceLocation, () -> json);
+    }
+
+    public enum RenderLayer {
+        SOLID("solid", RenderType::solid),
+        CUTOUT("cutout", RenderType::cutout),
+        CUTOUT_MIPPED("cutout_mipped", RenderType::cutoutMipped),
+        TRANSLUCENT("translucent", RenderType::translucent);
+
+        public final String name;
+        public final Supplier<RenderType> renderType;
+
+        RenderLayer(String name, Supplier<RenderType> renderType) {
+            this.name = name;
+            this.renderType = renderType;
+        }
+    }
+}

--- a/Common/src/main/java/com/almostreliable/almostlib/datagen/template/LayeredModelTemplate.java
+++ b/Common/src/main/java/com/almostreliable/almostlib/datagen/template/LayeredModelTemplate.java
@@ -32,7 +32,11 @@ public class LayeredModelTemplate extends ModelTemplate {
 
     @Override
     public ResourceLocation create(ResourceLocation resourceLocation, TextureMapping textureMapping, BiConsumer<ResourceLocation, Supplier<JsonElement>> biConsumer) {
-        return super.create(resourceLocation, textureMapping, (rl, supplier) -> injectRenderLayer(rl, supplier, biConsumer));
+        return super.create(
+            resourceLocation,
+            textureMapping,
+            renderLayer == RenderLayer.SOLID ? biConsumer : (rl, supplier) -> injectRenderLayer(rl, supplier, biConsumer)
+        );
     }
 
     private void injectRenderLayer(ResourceLocation resourceLocation, Supplier<JsonElement> supplier, BiConsumer<ResourceLocation, Supplier<JsonElement>> biConsumer) {

--- a/Common/src/main/java/com/almostreliable/almostlib/mixin/ModelTemplateAccessor.java
+++ b/Common/src/main/java/com/almostreliable/almostlib/mixin/ModelTemplateAccessor.java
@@ -1,0 +1,23 @@
+package com.almostreliable.almostlib.mixin;
+
+import net.minecraft.data.models.model.ModelTemplate;
+import net.minecraft.data.models.model.TextureSlot;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Mixin(ModelTemplate.class)
+public interface ModelTemplateAccessor {
+
+    @Accessor("model")
+    Optional<ResourceLocation> getModel();
+
+    @Accessor("requiredSlots")
+    Set<TextureSlot> getRequiredSlots();
+
+    @Accessor("suffix")
+    Optional<String> getSuffix();
+}

--- a/Common/src/main/resources/almostlib-common.mixins.json
+++ b/Common/src/main/resources/almostlib-common.mixins.json
@@ -5,7 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "CreativeModeTabAccessor",
-    "ItemPropertiesAccessor"
+    "ItemPropertiesAccessor",
+    "ModelTemplateAccessor"
   ],
   "client": [
   ],

--- a/Fabric/src/main/java/com/almostreliable/almostlib/fabric/FabricInitializer.java
+++ b/Fabric/src/main/java/com/almostreliable/almostlib/fabric/FabricInitializer.java
@@ -1,10 +1,25 @@
 package com.almostreliable.almostlib.fabric;
 
+import com.almostreliable.almostlib.datagen.template.LayeredModelTemplate;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 
 public class FabricInitializer implements ModInitializer {
 
     @Override
     public void onInitialize() {
+    }
+
+    @Environment(EnvType.CLIENT)
+    public static void initRenderType(ResourceLocation resourceLocation, LayeredModelTemplate.RenderLayer renderLayer) {
+        Block block = Registry.BLOCK.get(resourceLocation);
+        if (block.equals(Blocks.AIR)) return;
+        BlockRenderLayerMap.INSTANCE.putBlock(block, renderLayer.renderType.get());
     }
 }

--- a/Fabric/src/main/java/com/almostreliable/almostlib/fabric/FabricInitializer.java
+++ b/Fabric/src/main/java/com/almostreliable/almostlib/fabric/FabricInitializer.java
@@ -1,10 +1,10 @@
 package com.almostreliable.almostlib.fabric;
 
-import com.almostreliable.almostlib.datagen.template.LayeredModelTemplate;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
@@ -17,9 +17,9 @@ public class FabricInitializer implements ModInitializer {
     }
 
     @Environment(EnvType.CLIENT)
-    public static void initRenderType(ResourceLocation resourceLocation, LayeredModelTemplate.RenderLayer renderLayer) {
+    public static void initRenderType(ResourceLocation resourceLocation, RenderType renderType) {
         Block block = Registry.BLOCK.get(resourceLocation);
         if (block.equals(Blocks.AIR)) return;
-        BlockRenderLayerMap.INSTANCE.putBlock(block, renderLayer.renderType.get());
+        BlockRenderLayerMap.INSTANCE.putBlock(block, renderType);
     }
 }

--- a/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/BlockModelDeserializerMixin.java
+++ b/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/BlockModelDeserializerMixin.java
@@ -1,0 +1,36 @@
+package com.almostreliable.almostlib.fabric.mixin;
+
+import com.almostreliable.almostlib.datagen.template.LayeredModelTemplate.RenderLayer;
+import com.almostreliable.almostlib.fabric.FabricInitializer;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.minecraft.client.renderer.block.model.BlockElement;
+import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+@Mixin(BlockModel.Deserializer.class)
+public abstract class BlockModelDeserializerMixin {
+
+    @Inject(
+        method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/client/renderer/block/model/BlockModel;",
+        at = @At("TAIL"),
+        locals = LocalCapture.CAPTURE_FAILHARD
+    )
+    private void fetchRenderLayer(JsonElement element, Type type, JsonDeserializationContext context, CallbackInfoReturnable<BlockModel> cir, JsonObject json, List<BlockElement> list, String name) {
+        var renderLayer = RenderLayer.valueOf(GsonHelper.getAsString(json, "render_type", "solid").toUpperCase());
+        if (renderLayer == RenderLayer.SOLID) return;
+
+        ResourceLocation resourceLocation = name.isEmpty() ? null : new ResourceLocation(name);
+        if (resourceLocation != null) FabricInitializer.initRenderType(resourceLocation, renderLayer);
+    }
+}

--- a/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/BlockModelDeserializerMixin.java
+++ b/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/BlockModelDeserializerMixin.java
@@ -1,5 +1,6 @@
 package com.almostreliable.almostlib.fabric.mixin;
 
+import com.almostreliable.almostlib.AlmostManager;
 import com.almostreliable.almostlib.datagen.template.LayeredModelTemplate.RenderLayer;
 import com.almostreliable.almostlib.fabric.FabricInitializer;
 import com.google.gson.JsonDeserializationContext;
@@ -31,6 +32,8 @@ public abstract class BlockModelDeserializerMixin {
         if (renderLayer == RenderLayer.SOLID) return;
 
         ResourceLocation resourceLocation = name.isEmpty() ? null : new ResourceLocation(name);
-        if (resourceLocation != null) FabricInitializer.initRenderType(resourceLocation, renderLayer);
+        if (resourceLocation != null && AlmostManager.REGISTERED_MODS.contains(resourceLocation.getNamespace())) {
+            FabricInitializer.initRenderType(resourceLocation, renderLayer.renderType.get());
+        }
     }
 }

--- a/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/package-info.java
+++ b/Fabric/src/main/java/com/almostreliable/almostlib/fabric/mixin/package-info.java
@@ -1,0 +1,6 @@
+@ParametersAreNonnullByDefault @MethodsReturnNonnullByDefault
+package com.almostreliable.almostlib.fabric.mixin;
+
+import net.minecraft.MethodsReturnNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/Fabric/src/main/resources/almostlib-fabric.mixins.json
+++ b/Fabric/src/main/resources/almostlib-fabric.mixins.json
@@ -1,0 +1,13 @@
+{
+  "required": true,
+  "minVersion": "0.8.5",
+  "package": "com.almostreliable.almostlib.fabric.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [],
+  "client": [
+    "BlockModelDeserializerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -19,7 +19,8 @@
     ]
   },
   "mixins": [
-    "almostlib-common.mixins.json"
+    "almostlib-common.mixins.json",
+    "almostlib-fabric.mixins.json"
   ],
   "depends": {
     "fabric": ">=${fabricApiVersion}",


### PR DESCRIPTION
This pull request implements the ability to specify a render type for block models.

`LayeredModelTemplate` is now able to wrap a `ModelTemplate` in order to add the json property for the render type.
```
ModelTemplates.CROSS.create()
```
Can now be used with
```
LayeredModelTemplate.of(ModelTemplates.CROSS, LayeredModelTemplate.RenderLayer.CUTOUT).create()
```

While this works already fine on Forge because it only relies on the model json property, Fabric will be a bit more tricky. We still need to find a proper injection point where model jsons are being read, resolve the render type from the property and register the render type in the Fabric client environment.